### PR TITLE
Add possibility to load the repository configuration without interrupting operation

### DIFF
--- a/apps/cvmfs_gateway/src/cvmfs_app_util.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_app_util.erl
@@ -8,9 +8,46 @@
 
 -module(cvmfs_app_util).
 
--export([get_max_lease_time/0]).
+-export([get_max_lease_time/0,
+         read_config_file/1,
+         read_vars/2,
+         default_repo_config/0,
+         default_user_config/0]).
+
 
 get_max_lease_time() ->
     {ok, MaxLeaseTime} = application:get_env(cvmfs_gateway, max_lease_time),
     MaxLeaseTime.
 
+
+read_config_file(File) ->
+    case file:read_file(File) of
+        {ok, Data} ->
+            jsx:decode(Data, [{labels, atom}, return_maps]);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+
+read_vars(VarName, Defaults) ->
+    case application:get_env(VarName) of
+        {ok, {file, ConfigFile}} ->
+            read_config_file(ConfigFile);
+        {ok, ConfigMap} ->
+            ConfigMap;
+        undefined ->
+            Defaults
+    end.
+
+
+default_repo_config() ->
+    #{repos => [], keys => []}.
+
+
+default_user_config() ->
+    #{max_lease_time => 7200,
+      fe_tcp_port => 8080,
+      receiver_config => #{size => 1,
+                           max_overflow => 1},
+      receiver_worker_config =>
+          #{executable_path => "/usr/bin/cvmfs_receiver"}}.

--- a/apps/cvmfs_gateway/src/cvmfs_be.erl
+++ b/apps/cvmfs_gateway/src/cvmfs_be.erl
@@ -125,7 +125,7 @@ submit_payload(Uid, SubmissionData) ->
                     cvmfs_app_util:get_max_lease_time()).
 
 
--spec get_repos(Uid :: binary()) -> [binary()].
+-spec get_repos(Uid :: binary()) -> [{binary(), [binary()]}].
 get_repos(Uid) ->
     gen_server:call(?MODULE, {be_req, get_repos, Uid}, cvmfs_app_util:get_max_lease_time()).
 
@@ -385,7 +385,7 @@ p_submit_payload({LeaseToken, _Payload, _Digest, _HeaderSize} = SubmissionData) 
     Result.
 
 
--spec p_get_repos() -> Repos :: [binary()].
+-spec p_get_repos() -> Repos :: [{binary(), [binary()]}].
 p_get_repos() ->
     cvmfs_auth:get_repos().
 

--- a/rebar.config
+++ b/rebar.config
@@ -34,6 +34,7 @@
                   ,{copy, "./scripts/get_leases.escript", "scripts/get_leases.escript"}
                   ,{copy, "./scripts/clear_leases.sh",      "scripts/clear_leases.sh"}
                   ,{copy, "./scripts/clear_leases.escript", "scripts/clear_leases.escript"}
+                  ,{copy, "./scripts/reload_repo_config.escript", "scripts/reload_repo_config.escript"}
                   ,{copy, "./scripts/setup.sh", "scripts/setup.sh"}
                   ,{copy, "./scripts/setup_mnesia.escript", "scripts/setup_mnesia.escript"}
                   ,{copy, "./scripts/cvmfs_gateway.service", "scripts/cvmfs_gateway.service"}]}

--- a/scripts/cvmfs_gateway.service
+++ b/scripts/cvmfs_gateway.service
@@ -6,7 +6,7 @@ After=syslog.target network.target
 Type=forking
 ExecStart=/opt/cvmfs_gateway/scripts/run_cvmfs_gateway.sh start
 ExecStop=/opt/cvmfs_gateway/scripts/run_cvmfs_gateway.sh stop
-ExecReload=/opt/cvmfs_gateway/scripts/run_cvmfs_gateway.sh restart
+ExecReload=/opt/cvmfs_gateway/scripts/run_cvmfs_gateway.sh reload
 User=root
 
 [Install]

--- a/scripts/reload_repo_config.escript
+++ b/scripts/reload_repo_config.escript
@@ -1,0 +1,18 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+%%! -sname cvmfs_gateway_ops -setcookie cvmfs
+
+%%% -------------------------------------------------------------------
+%%%
+%%%  This file is part of the CernVM File System.
+%%%
+%%% -------------------------------------------------------------------
+
+main([]) ->
+    io:format("Node name: ~p.~n", [node()]),
+    io:format("Reloading repository configuration... "),
+    [HostName | _] = string:split(net_adm:localhost(), "."),
+    MainNodeAtom = list_to_atom("cvmfs_gateway@" ++ HostName),
+    ok = rpc:call(MainNodeAtom, cvmfs_auth, reload_repo_config, []),
+    io:format("done.~n"),
+    halt(0).

--- a/scripts/run_cvmfs_gateway.sh
+++ b/scripts/run_cvmfs_gateway.sh
@@ -29,6 +29,9 @@ elif [ x"$action" = xstop ]; then
     $SCRIPT_LOCATION/../bin/cvmfs_gateway stop
     pkill epmd
     echo "CVMFS repository gateway stopped."
+elif [ x"$action" = xreload ]; then
+    $SCRIPT_LOCATION/../bin/cvmfs_gateway escript scripts/reload_repo_config.escript
+    echo "CVMFS repository gateway configuration reloaded."
 elif [ x"$action" = xrestart ]; then
     $SCRIPT_LOCATION/../bin/cvmfs_gateway stop
     pkill epmd
@@ -39,6 +42,6 @@ elif [ x"$action" = xstatus ]; then
     $SCRIPT_LOCATION/../bin/cvmfs_gateway ping
 else
     echo "Unknown action: $action"
-    echo "Usage: run_cvmfs_gateway.sh <start|stop|restart|status>"
+    echo "Usage: run_cvmfs_gateway.sh <start|stop|reload|restart|status>"
     exit 1
 fi


### PR DESCRIPTION
Using this functionality, repositories and keys can be added or removed without interrupting the operation of the repository gateway.